### PR TITLE
Minify embedded frame bundle for readable srcdoc

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,5 +23,17 @@ export default tseslint.config(
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
     },
+  },
+  {
+    files: ['lib/frame-bundle.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      sourceType: 'commonjs',
+    },
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+    },
   }
 );

--- a/lib/frame-bundle.js
+++ b/lib/frame-bundle.js
@@ -1,0 +1,61 @@
+// val-loader entry: compiles frame.ts to a single minified JS string at build time.
+// Returned value becomes the module.exports of `val-loader!./frame-bundle.js`.
+
+const path = require('path');
+const webpack = require('webpack');
+const { createFsFromVolume, Volume } = require('memfs');
+
+const FRAME_ENTRY = path.resolve(__dirname, 'frame.ts');
+
+module.exports = function frameBundle() {
+  const compiler = webpack({
+    mode: 'production',
+    target: 'web',
+    devtool: false,
+    entry: FRAME_ENTRY,
+    output: {
+      path: '/',
+      filename: 'frame.js',
+      iife: true
+    },
+    resolve: {
+      extensions: ['.ts', '.js']
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          loader: 'ts-loader',
+          options: { transpileOnly: true }
+        }
+      ]
+    },
+    performance: { hints: false }
+  });
+
+  const memFs = createFsFromVolume(new Volume());
+  compiler.outputFileSystem = memFs;
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      const close = () => new Promise((res) => compiler.close(() => res()));
+      if (err) {
+        close().then(() => reject(err));
+        return;
+      }
+      if (stats.hasErrors()) {
+        close().then(() => reject(new Error(stats.toString({ errors: true }))));
+        return;
+      }
+      const code = memFs.readFileSync('/frame.js', 'utf8');
+      close().then(() => {
+        resolve({
+          code: 'module.exports = ' + JSON.stringify(code),
+          cacheable: true,
+          dependencies: [FRAME_ENTRY],
+          buildDependencies: [__filename]
+        });
+      });
+    });
+  });
+};

--- a/lib/websandbox.ts
+++ b/lib/websandbox.ts
@@ -1,6 +1,6 @@
 import Connection from './connection';
 // @ts-expect-error loader-based input
-import CompiledFrameScript from 'compile-code-loader!./frame.ts';
+import CompiledFrameScript from 'val-loader!./frame-bundle.js';
 import { API } from './types';
 
 export interface SandboxOptions {
@@ -36,13 +36,7 @@ export const BaseOptions: SandboxOptions = {
   frameContainer: 'body',
   frameClassName: 'websandbox__frame',
   frameSrc: null,
-  frameContent: `
-<!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"></head>
-<body></body>
-</html>
-  `,
+  frameContent: '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body></body></html>',
   codeToRunBeforeInit: null,
   initialStyles: null,
   baseUrl: null,
@@ -118,20 +112,20 @@ class Websandbox {
 
     if (options.codeToRunBeforeInit) {
       frameContent = frameContent
-        .replace('<head>', `<head>\n<script>${options.codeToRunBeforeInit}</script>`) ?? '';
+        .replace('<head>', `<head><script>${options.codeToRunBeforeInit}</script>`) ?? '';
     }
 
     frameContent = frameContent
-      .replace('<head>', `<head>\n<script>${CompiledFrameScript}</script>`) ?? '';
+      .replace('<head>', `<head><script>${CompiledFrameScript}</script>`) ?? '';
 
     if (options.initialStyles) {
       frameContent = frameContent
-        .replace('</head>', `<style>${options.initialStyles}</style>\n</head>`);
+        .replace('</head>', `<style>${options.initialStyles}</style></head>`);
     }
 
     if (options.baseUrl) {
       frameContent = frameContent
-        .replace('<head>', `<head>\n<base target="_parent" href="${options.baseUrl}"/>`);
+        .replace('<head>', `<head><base target="_parent" href="${options.baseUrl}"/>`);
     }
 
     return frameContent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@eslint/js": "^9.39.3",
         "ajv": "^8.18.0",
         "chai": "4.5.0",
-        "compile-code-loader": "^1.0.0",
         "electron": "40.6.0",
         "eslint": "^9.39.3",
         "gh-pages": "^6.3.0",
@@ -27,6 +26,7 @@
         "karma-sinon-chai": "2.0.2",
         "karma-sourcemap-loader": "0.4.0",
         "karma-webpack": "5.0.1",
+        "memfs": "^4.57.2",
         "mocha": "11.7.5",
         "sinon": "21.0.1",
         "sinon-chai": "^3.7.0",
@@ -34,6 +34,7 @@
         "ts-loader": "^9.5.4",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.0",
+        "val-loader": "^6.0.0",
         "webpack": "5.105.2",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "5.2.3"
@@ -554,14 +555,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
-      "integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+      "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -576,15 +577,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
-      "integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+      "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -599,17 +600,17 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
-      "integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+      "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
-        "@jsonjoy.com/fs-print": "4.56.10",
-        "@jsonjoy.com/fs-snapshot": "4.56.10",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -625,9 +626,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
-      "integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -642,15 +643,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
-      "integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+      "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10"
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -664,13 +665,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
-      "integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+      "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.56.10"
+        "@jsonjoy.com/fs-node-builtins": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -684,13 +685,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
-      "integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+      "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -705,14 +706,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
-      "integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+      "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -2310,16 +2311,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2863,16 +2854,6 @@
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
-      }
-    },
-    "node_modules/compile-code-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/compile-code-loader/-/compile-code-loader-1.0.0.tgz",
-      "integrity": "sha512-MFE1K+xC3f28urqFQ/7LGAzl/MZXzrFz5n3Tp83n6DwiucAVPkbB+z18D7Z0BqvmcuFiYy6hgm9sGrF/mbyZUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0"
       }
     },
     "node_modules/compressible": {
@@ -3956,16 +3937,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -6257,19 +6228,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6584,21 +6542,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6777,20 +6720,20 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.56.10",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
-      "integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.10",
-        "@jsonjoy.com/fs-fsa": "4.56.10",
-        "@jsonjoy.com/fs-node": "4.56.10",
-        "@jsonjoy.com/fs-node-builtins": "4.56.10",
-        "@jsonjoy.com/fs-node-to-fsa": "4.56.10",
-        "@jsonjoy.com/fs-node-utils": "4.56.10",
-        "@jsonjoy.com/fs-print": "4.56.10",
-        "@jsonjoy.com/fs-snapshot": "4.56.10",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -10196,6 +10139,23 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/val-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/val-loader/-/val-loader-6.0.0.tgz",
+      "integrity": "sha512-NHi81ow+/mVBRuFRNxp8tfTSnAIFsq/wzZGqxv/a82Y722GQSOQi9yP0GuenSBiuw4+zGjmW/H9sLTbP3bewrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetbrains/websandbox",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A sandbox library for runnung javascript inside HTML5 sandboxed iframe",
   "main": "dist/websandbox.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@eslint/js": "^9.39.3",
     "ajv": "^8.18.0",
     "chai": "4.5.0",
-    "compile-code-loader": "^1.0.0",
     "electron": "40.6.0",
     "eslint": "^9.39.3",
     "gh-pages": "^6.3.0",
@@ -48,6 +47,7 @@
     "karma-sinon-chai": "2.0.2",
     "karma-sourcemap-loader": "0.4.0",
     "karma-webpack": "5.0.1",
+    "memfs": "^4.57.2",
     "mocha": "11.7.5",
     "sinon": "21.0.1",
     "sinon-chai": "^3.7.0",
@@ -55,6 +55,7 @@
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",
+    "val-loader": "^6.0.0",
     "webpack": "5.105.2",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "5.2.3"

--- a/test/sandbox.test.js
+++ b/test/sandbox.test.js
@@ -20,7 +20,7 @@ describe('Sandbox', function () {
 
     it('should create iframe with correct srcdoc', function () {
         Sandbox.create({});
-        document.querySelector('iframe').srcdoc.should.contain(`TYPE_SET_INTERFACE`);
+        document.querySelector('iframe').srcdoc.should.contain(`set-interface`);
     });
 
     it('should support passing custom frameContent', function () {
@@ -32,7 +32,7 @@ describe('Sandbox', function () {
             </html>
         `});
 
-        document.querySelector('iframe').srcdoc.should.contain(`TYPE_SET_INTERFACE`);
+        document.querySelector('iframe').srcdoc.should.contain(`set-interface`);
         document.querySelector('iframe').srcdoc.should.contain('this is custom frame content');
     });
 


### PR DESCRIPTION
## Summary
- Replace abandoned `compile-code-loader` with `val-loader` + an in-memory webpack child compile in `mode: 'production'`. The embedded frame bundle drops from ~17 KiB unminified to **~4.4 KiB on a single line**.
- Flatten `BaseOptions.frameContent` and remove `\n` from `_prepareFrameContent` injection points so the final iframe `srcdoc` attribute renders as **one line** in DevTools.
- Switch test assertion from minified-away symbol `TYPE_SET_INTERFACE` to its inlined value `set-interface`.

Closes #45.

## Why val-loader
`compile-code-loader` is unmaintained (~8 years), relies on webpack-v4 internals (`SingleEntryPlugin`), and only emitted a development-mode bundle. `val-loader` is the canonical webpack-5 way to "execute a module at build time and embed its output", so the frame bundle is now produced by a real production-mode webpack compile (terser minification + IIFE).

## Files
- `lib/frame-bundle.js` — new val-loader entry; runs webpack on `frame.ts` with `memfs`, returns the minified bundle string.
- `lib/websandbox.ts` — import path swapped to `val-loader!./frame-bundle.js`; `BaseOptions.frameContent` and injection helpers single-lined.
- `eslint.config.mjs` — file-scoped override (node globals, CommonJS, allow `require`) for `lib/frame-bundle.js`.
- `test/sandbox.test.js` — assertion updated to runtime value, no semantic change.
- `package.json` / `package-lock.json` — drop `compile-code-loader`, add `val-loader` + `memfs`.

## Test plan
- [x] `npm test` — 46/46 karma tests green.
- [x] `npm run lint` — clean.
- [x] `npm run build` — produces `dist/websandbox.js`; embedded bundle is 4424 bytes, 0 newlines.
- [x] `npm run build-examples` + browser smoke: `simple.html` sandbox initialises, host ↔ sandbox round-trip works, DevTools shows `srcdoc` on one line.