### PR TITLE
Harden postMessage bridge and object path traversal

### DIFF
--- a/lib/connection.ts
+++ b/lib/connection.ts
@@ -1,4 +1,4 @@
-import { propertyByPath, splitPath } from "./object-path";
+import { propertyByPath, splitPath, hasUnsafeSegments } from "./object-path";
 import type {API} from "./types";
 
 export const TYPE_MESSAGE = 'message';
@@ -10,9 +10,7 @@ export const TYPE_SERVICE_MESSAGE = 'service-message';
 const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
 
 const defaultOptions = {
-  //Will not affect IE11 because there sandboxed iframe has not 'null' origin
-  //but base URL of iframe's src
-  allowedSenderOrigin: undefined
+  allowedSenderOrigin: 'null'
 };
 
 export interface ConnectionOptions {
@@ -91,8 +89,10 @@ class Connection {
 
     remoteMethods.forEach(
       (key: string) => {
-        // If key is nested, we need to create nested structure
         const parts = splitPath(key);
+        if (hasUnsafeSegments(parts)) {
+          return;
+        }
         let current = this.remote;
         for (let i = 0; i < parts.length - 1; i++)
         {

--- a/lib/frame.ts
+++ b/lib/frame.ts
@@ -14,7 +14,8 @@ class Frame {
           return listener(event);
         };
         window.addEventListener('message', sourceCheckListener);
-      }
+      },
+      {allowedSenderOrigin: undefined}
     );
 
     this.connection.setServiceMethods({

--- a/lib/object-path.ts
+++ b/lib/object-path.ts
@@ -1,6 +1,7 @@
 type AnyObject = any;
 
 const PATH_REG = /([.[\]:;'"\s])/;
+const UNSAFE_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
 
 export function escapePathPart(pathPart: string): string {
   if (!PATH_REG.test(pathPart)) {
@@ -31,17 +32,19 @@ export function splitPath(path: string): string[] {
   return result.filter(pathPart => !!pathPart).map(pathPart => pathPart.replace(/\\/g, ''));
 }
 
-/**
- * Extracts object property value by given path. Supports nested and array values: 'foo[0].bar'
- * @param {Object} object source object
- * @param {string} path path to value
- * @return {any | null} value by given path
- * */
+export function hasUnsafeSegments(parts: string[]): boolean {
+  return parts.some(part => UNSAFE_SEGMENTS.has(part));
+}
+
 export function propertyByPath<R extends AnyObject, O extends AnyObject = AnyObject>(
   object: O,
   path: string,
 ): R | null {
-  return splitPath(path).reduce<R | null>(
+  const parts = splitPath(path);
+  if (hasUnsafeSegments(parts)) {
+    return null;
+  }
+  return parts.reduce<R | null>(
     (acc, pathPart) => {
       if (acc) {
         return (acc as {[k: string]: R})[pathPart];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetbrains/websandbox",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A sandbox library for runnung javascript inside HTML5 sandboxed iframe",
   "main": "dist/websandbox.js",
   "scripts": {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -33,6 +33,7 @@ describe('Connection', function () {
 
         //Emulate response
         callMessageListener({
+            origin: 'null',
             data: {
                 callId: this.postMessage.getCall(0).args[0].callId,
                 type: TYPE_RESPONSE,
@@ -57,7 +58,7 @@ describe('Connection', function () {
 
     it('should accept nested methods in setInterface', function () {
         const conn = new Connection(this.postMessage, this.registerOnMessageListener);
-        
+
         conn.setInterface(['flat', 'nested.method']);
         conn.remote.flat.should.be.a('function');
         conn.remote.nested.method.should.be.a('function');
@@ -80,6 +81,7 @@ describe('Connection', function () {
 
         //Emulate response
         callMessageListener({
+            origin: 'null',
             data: {
                 callId: this.postMessage.getCall(0).args[0].callId,
                 type: TYPE_RESPONSE,
@@ -104,6 +106,7 @@ describe('Connection', function () {
         await conn.setLocalApi(this.localApi);
 
         callMessageListener({
+            origin: 'null',
             data: {
                 callId: CALL_ID,
                 type: TYPE_MESSAGE,
@@ -122,8 +125,9 @@ describe('Connection', function () {
         this.localApi.testLocalMethod.returns({fake: TYPE_RESPONSE});
 
         await conn.setLocalApi(this.localApi);
-        
+
         callMessageListener({
+            origin: 'null',
             data: {
                 callId: CALL_ID,
                 type: TYPE_MESSAGE,
@@ -134,7 +138,7 @@ describe('Connection', function () {
 
         // Wait for the asynchronous message handling
         await new Promise(resolve => setTimeout(resolve, 10));
-        
+
         this.postMessage.should.have.been.calledWith({
             callId: "fake-call-id",
             result: {fake: TYPE_RESPONSE},
@@ -151,8 +155,9 @@ describe('Connection', function () {
         this.localApi.nested.method.returns({fake: TYPE_RESPONSE});
 
         await conn.setLocalApi(this.localApi);
-        
+
         callMessageListener({
+            origin: 'null',
             data: {
                 callId: CALL_ID,
                 type: TYPE_MESSAGE,
@@ -163,7 +168,7 @@ describe('Connection', function () {
 
         // Wait for the asynchronous message handling
         await new Promise(resolve => setTimeout(resolve, 10));
-        
+
         this.postMessage.should.have.been.calledWith({
             callId: "fake-call-id",
             result: {fake: TYPE_RESPONSE},
@@ -172,15 +177,37 @@ describe('Connection', function () {
         }, '*');
     });
 
+    it('should reject messages from non-null origins by default', function () {
+        const conn = new Connection(this.postMessage, this.registerOnMessageListener);
+        conn.setInterface(['testMethod']);
+
+        callMessageListener({
+            origin: 'https://evil.example.com',
+            data: {
+                callId: 'evil',
+                type: 'set-interface',
+                apiMethods: ['polluted']
+            }
+        });
+
+        conn.remote.should.not.have.property('polluted');
+    });
+
+    it('should not register __proto__ methods via setInterface', function () {
+        const conn = new Connection(this.postMessage, this.registerOnMessageListener);
+        conn.setInterface(['__proto__.polluted']);
+        ({}).should.not.have.property('polluted');
+    });
+
     it('should resolve remote methods wait promise', async function () {
         const resolved = sinon.spy();
         const conn = new Connection(this.postMessage, this.registerOnMessageListener);
-        
+
         Promise.resolve(conn.remoteMethodsWaitPromise).then(resolved);
 
         await new Promise(resolve => setTimeout(resolve));
         resolved.should.not.have.been.called;
-        
+
         conn.setInterface(['testMethod']);
         await new Promise(resolve => setTimeout(resolve));
         resolved.should.have.been.called;

--- a/test/object-path.test.js
+++ b/test/object-path.test.js
@@ -81,5 +81,28 @@ describe('object extensions', () => {
 
     it('should split square bracketed path with space', () =>
       (splitPath('foo["with\\ dots"].test')).should.deep.equal(['foo', 'with dots', 'test']));
+
+  });
+
+  describe('prototype pollution protection', () => {
+    it('should not resolve __proto__ path in propertyByPath', () => {
+      const obj = {safe: {value: 42}};
+      (propertyByPath(obj, '__proto__') === null).should.be.true;
+    });
+
+    it('should not resolve constructor path in propertyByPath', () => {
+      const obj = {safe: {value: 42}};
+      (propertyByPath(obj, 'constructor') === null).should.be.true;
+    });
+
+    it('should not resolve nested __proto__ path', () => {
+      const obj = {foo: {bar: 1}};
+      (propertyByPath(obj, 'foo.__proto__.bar') === null).should.be.true;
+    });
+
+    it('should not resolve constructor.prototype path', () => {
+      const obj = {foo: 1};
+      (propertyByPath(obj, 'constructor.prototype') === null).should.be.true;
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Default `allowedSenderOrigin` to `'null'` in `Connection` so the origin check is active unless explicitly opted out
- Reject unsafe path segments (`__proto__`, `constructor`, `prototype`) in `setInterface()` and `propertyByPath()`
- Frame-side connection explicitly opts out of origin check (relies on `event.source` guard)
- Version bump to 1.3.0

Fixes issue https://youtrack.jetbrains.com/issue/JT-96770

## Test plan
- [x] All 52 existing + new tests pass
- [ ] Verify sandbox integration works end-to-end in consuming app